### PR TITLE
Allow offsets (eg. +00.00) in timestamps from notion

### DIFF
--- a/packages/notion-astro-loader/src/schemas/raw-properties.ts
+++ b/packages/notion-astro-loader/src/schemas/raw-properties.ts
@@ -29,7 +29,7 @@ const selectPropertyResponse = z.object({
   name: z.string(),
   color: z.string(),
 });
-const dateField = z.union([z.string().date(), z.string().datetime()]);
+const dateField = z.union([z.string().date(), z.string().datetime({ offset: true })]);
 const dateResponse = z.object({
   start: dateField,
   end: dateField.nullable(),
@@ -42,7 +42,7 @@ const formulaPropertyResponse = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("date"),
-    date: z.string().datetime().nullable(),
+    date: z.string().datetime({ offset: true }).nullable(),
   }),
   z.object({
     type: z.literal("number"),
@@ -136,7 +136,7 @@ export const files = propertySchema(
 export const created_by = propertySchema("created_by", userObjectResponse);
 export const created_time = propertySchema(
   "created_time",
-  z.string().datetime(),
+  z.string().datetime({ offset: true }),
 );
 export const last_edited_by = propertySchema(
   "last_edited_by",
@@ -144,7 +144,7 @@ export const last_edited_by = propertySchema(
 );
 export const last_edited_time = propertySchema(
   "last_edited_time",
-  z.string().datetime(),
+  z.string().datetime({ offset: true }),
 );
 export const formula = propertySchema("formula", formulaPropertyResponse);
 export const title = propertySchema("title", z.array(richTextItemResponse));
@@ -165,7 +165,7 @@ export const rollup = propertySchema(
     z.object({
       function: z.string(),
       type: z.literal("date"),
-      date: z.string().datetime().nullable(),
+      date: z.string().datetime({ offset: true }).nullable(),
     }),
     z.object({
       function: z.string(),


### PR DESCRIPTION
Not sure if this is a recent change, but Notion likes to dish me timestamps that include offsets (eg. '2023-02-02T00:00:00.000+00:00'). This change tells Zod to allow them. It does not otherwise change or restrict parsing behaviour - this is a safe change!

Great work with this Notion loader tool by the way - exactly what I was after! 