### PR TITLE
Add image fetching when rendering

### DIFF
--- a/packages/notion-astro-loader/README.md
+++ b/packages/notion-astro-loader/README.md
@@ -71,6 +71,8 @@ export default defineConfig({
 });
 ```
 
+Properties must be transformed manually as Notion doesn't disambiguate between images and other file types like PDF. Async transformers can be used to make this easier, using the `fileToImageAsset` formatter.
+
 ### Advanced Schema
 
 Helper Zod schemas are provided to let you customize and transform Notion page properties.
@@ -111,6 +113,7 @@ A few helper functions are provided for transforming Notion API objects into sim
 
 - `richTextToPlainText` converts [rich text](https://developers.notion.com/reference/rich-text) into plain strings
 - `fileToUrl` converts [file objects](https://developers.notion.com/reference/file-object) to a URL string.
+- `fileToImageAsset` converts [file objects](https://developers.notion.com/reference/file-object) to an image asset using the [Astro Asset API](https://docs.astro.build/en/reference/modules/astro-assets/#getimage).
 - `dateToDateObjects` converts the strings in a [date property](https://developers.notion.com/reference/page-property-values#date) into `Date`s.
 
 ## Options

--- a/packages/notion-astro-loader/README.md
+++ b/packages/notion-astro-loader/README.md
@@ -51,6 +51,26 @@ export const collections = { database };
 
 You can then use these like any other content collection in Astro. The data is type-safe, and the types are automatically generated based on the schema of the Notion database.
 
+### Images
+
+Notion stores images in remote AWS buckets, and this loader will automatically try to process them using the [Astro Asset API](https://docs.astro.build/en/reference/modules/astro-assets/#getimage). To make this work, add the following to your [`astro.config.js` file](https://docs.astro.build/en/reference/configuration-reference/#imageremotepatterns):
+
+```js
+// astro.config.js
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  image: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com",
+      },
+    ],
+  },
+});
+```
+
 ### Advanced Schema
 
 Helper Zod schemas are provided to let you customize and transform Notion page properties.

--- a/packages/notion-astro-loader/src/format.ts
+++ b/packages/notion-astro-loader/src/format.ts
@@ -1,3 +1,7 @@
+import type { GetImageResult } from "astro";
+import { getImage } from "astro:assets";
+import type { FileObject } from "./types.js";
+
 /**
  * Extract a plain string from a list of rich text items.
  *
@@ -17,12 +21,9 @@ export function richTextToPlainText(
  *
  * @see https://developers.notion.com/reference/file-object
  */
-export function fileToUrl(
-  file:
-    | { type: "external"; external: { url: string } }
-    | { type: "file"; file: { url: string } }
-    | null,
-): string | undefined {
+export function fileToUrl(file: FileObject): string;
+export function fileToUrl(file: FileObject | null): string | undefined;
+export function fileToUrl(file: FileObject | null): string | undefined {
   switch (file?.type) {
     case "external":
       return file.external.url;
@@ -31,6 +32,19 @@ export function fileToUrl(
     default:
       return undefined;
   }
+}
+
+/**
+ * Extract and locally cache the image from a file object.
+ * @see https://developers.notion.com/reference/file-object
+ */
+export async function fileToImageAsset(
+  file: FileObject,
+): Promise<GetImageResult> {
+  return getImage({
+    src: fileToUrl(file),
+    inferSize: true,
+  });
 }
 
 /**

--- a/packages/notion-astro-loader/src/index.ts
+++ b/packages/notion-astro-loader/src/index.ts
@@ -1,3 +1,3 @@
-export { richTextToPlainText, fileToUrl } from "./format.js";
+export { richTextToPlainText, fileToUrl, fileToImageAsset } from "./format.js";
 export { type NotionLoaderOptions, notionLoader } from "./loader.js";
 export { notionPageSchema } from "./schemas/page.js";

--- a/packages/notion-astro-loader/src/loader.ts
+++ b/packages/notion-astro-loader/src/loader.ts
@@ -113,7 +113,7 @@ export function notionLoader({
         if (existingPage?.digest !== page.last_edited_time) {
           const renderer = new NotionPageRenderer(notionClient, page, logger);
 
-          const data = await parseData(renderer.getPageData());
+          const data = await parseData(await renderer.getPageData());
           const renderPromise = renderer.render(processor).then((rendered) => {
             store.set({
               id: page.id,

--- a/packages/notion-astro-loader/src/types.ts
+++ b/packages/notion-astro-loader/src/types.ts
@@ -41,3 +41,7 @@ export type NotionPageData = Pick<
   | "public_url"
   | "properties"
 >;
+
+export type FileObject =
+  | { type: "external"; external: { url: string } }
+  | { type: "file"; file: { url: string } };


### PR DESCRIPTION
Based on #9

Images are now processed using Astro's `getImage` function when rendering. This gives a local cache for the remote images. URLs must be added to `image.remotePatterns` in the config to make this work.

Additionally a new formatter has been added to make it easier to transform image properties. This is an alternative to just passing the image property content to `<Image />` in your source code like the travel site does.