### PR TITLE
Handle video block (at least for loom)

### DIFF
--- a/packages/notion-astro-loader/src/render.ts
+++ b/packages/notion-astro-loader/src/render.ts
@@ -113,6 +113,19 @@ async function* listBlocks(
           caption: block.image.caption,
         },
       };
+    } 
+    // Handle video blocks
+    else if (block.type === "video") {
+      yield {
+        ...block,
+        video: {
+          type: block.video.type,
+          [block.video.type]: block.video.type === "external" 
+            ? block.video.external.url 
+            : block.video.file.url,
+          caption: block.video.caption,
+        },
+      };
     } else {
       yield block;
     }


### PR DESCRIPTION
This patch adds proper `src` to video block instead of `[Object, Object]`